### PR TITLE
Full ownership to creator, read only to others

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -325,7 +325,7 @@ class Command extends SymfonyCommand
     private function mkdir(string $fileDestinationPath): bool
     {
         if (file_exists(dirname($fileDestinationPath)) === false) {
-            mkdir(dirname($fileDestinationPath), 0777, true);
+            mkdir(dirname($fileDestinationPath), 0744, true);
         }
 
         if (is_writable(dirname($fileDestinationPath)) === false) {


### PR DESCRIPTION
Allowing full access (read, write and execute) to other users than creator is a bad default setting.