### PR TITLE
Checking inode will speed up when using --link

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Note: shortcuts cannot be combined, `-nv` will not work. This is a limitation of
 
 ### About
 #### Speed
-For a structure with 3494 files (41.6GB), it took 0.29s on first run. Subsequent execution will take much much longer
-time because we compare the checksum of both destination and source files.
+For a structure with 3494 files (41.6GB), it took 0.29s on first run. Subsequent execution will take much longer
+time because we compare the checksum of both destination and source files _(if not using --link).
 
 #### Date and time from files
 Date is retrieved from files in the following order:

--- a/src/Command.php
+++ b/src/Command.php
@@ -468,7 +468,14 @@ class Command extends SymfonyCommand
     private function isDuplicate(string $fileSourcePath, string $fileDestinationPath): bool
     {
         if (filesize($fileSourcePath) === filesize($fileDestinationPath)) {
-            return hash_file('md5', $fileSourcePath) === hash_file('md5', $fileDestinationPath);
+            $sourceInode = fileinode($fileSourcePath);
+            $destinationInode = fileinode($fileDestinationPath);
+
+            if ((!$sourceInode && !$destinationInode) || ($sourceInode !== $destinationInode)) {
+                return hash_file('md5', $fileSourcePath) === hash_file('md5', $fileDestinationPath);
+            }
+
+            return $sourceInode === $destinationInode;
         }
 
         return false;


### PR DESCRIPTION
Checking if inode in source and destination is the same is a LOT faster than
checking the hash. (went from 2min to 0.5sek with 41.6GB of files)


Related to #2 